### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ With this in place, users can run the `@cargo_raze//:raze` target to generate ne
 files. eg:
 
 ```bash
-bazel run @cargo_raze//:raze -- --manifest-path=$(pwd)/Cargo.toml
+bazel run @cargo_raze//:raze -- --manifest-path=$(realpath /Cargo.toml)
 ```
 
 Note that users using the `vendored` genmode will still have to vendor their dependencies


### PR DESCRIPTION
Fixes faulty invocation by using `realpath` instead of `pwd`.
Faulty:
 ```bash
» bazel run @cargo_raze//:raze -- --manifest-path=Cargo.toml
INFO: Analyzed target @cargo_raze//:raze (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @cargo_raze//impl:cargo_raze_bin up-to-date:
  bazel-bin/external/cargo_raze/impl/cargo_raze_bin
INFO: Elapsed time: 0.513s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Error: No such file or directory (os error 2)
```

Works:
```bash
» bazel run @cargo_raze//:raze -- --manifest-path=$(realpath Cargo.toml)
INFO: Analyzed target @cargo_raze//:raze (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @cargo_raze//impl:cargo_raze_bin up-to-date:
  bazel-bin/external/cargo_raze/impl/cargo_raze_bin
INFO: Elapsed time: 0.604s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
```